### PR TITLE
Set correct required attributes for HubClientInfo object

### DIFF
--- a/src/main/resources/schema/client_info
+++ b/src/main/resources/schema/client_info
@@ -24,7 +24,9 @@
     }
   },
   "required": [
-    "result",
-    "timeout"
+    "party_id",
+    "country_code",
+    "role",
+    "status"
   ]
 }


### PR DESCRIPTION
Update the list of required attributes according to the documentation. Note: officially "last_updated" is also mandatory (15.4.1), but the example is without last_updated (15.3.1.2)